### PR TITLE
lighttpd.conf: mod_compress deprecated

### DIFF
--- a/data/configs/lighttpd.conf
+++ b/data/configs/lighttpd.conf
@@ -4,7 +4,7 @@
 server.modules = (
     "mod_access",
     "mod_alias",
-    "mod_compress",
+    "mod_deflate",
     "mod_redirect",
     "mod_rewrite",
 )
@@ -22,8 +22,8 @@ index-file.names            = ( "index.php", "index.html", "index.lighttpd.html"
 url.access-deny             = ( "~", ".inc" )
 static-file.exclude-extensions = ( ".php", ".pl", ".fcgi" )
 
-compress.cache-dir          = "/var/cache/lighttpd/compress/"
-compress.filetype           = ( "application/javascript", "text/css", "text/html", "text/plain" )
+deflate.cache-dir           = "/var/cache/lighttpd/compress/"
+deflate.mimetypes           = ( "application/javascript", "text/css", "text/html", "text/plain" )
 
 # default listening port for IPv6 falls back to the IPv4 port
 ## Use ipv6 if available


### PR DESCRIPTION
mod_compress has been subsumed by and replaced with mod_deflate since lighttpd 1.4.56.
Release note: https://www.lighttpd.net/2020/11/29/1.4.56/

Fixes startup warnings:
```
configfile.c.461) Warning: "mod_compress" is DEPRECATED and has been replaced with "mod_deflate".  A future release of lighttpd 1.4.x will not contain mod_compress and lighttpd may fail to start up
mod_deflate.c.567) DEPRECATED: compress.filetype replaced with deflate.mimetypes
mod_deflate.c.580) DEPRECATED: compress.cache-dir replaced with deflate.cache-dir
```