### PR TITLE
Add support for BIRD 2.0.7 status output

### DIFF
--- a/app/Bird/Parser/Status.php
+++ b/app/Bird/Parser/Status.php
@@ -25,13 +25,13 @@ class Status extends Parser
             else if( preg_match( "/^Router\sID\sis\s([0-9\.]+)\s*$/", $line, $matches ) ) {
                 $response['router_id'] = $matches[1];
             }
-            else if( preg_match( "/^Current\sserver\stime\sis\s([0-9\-]+)\s([0-9\:]+)\s*$/", $line, $matches ) ) {
+            else if( preg_match( "/^Current\sserver\stime\sis\s([0-9\-]+)\s([0-9\:]+)[0-9\.]*?\s*$/", $line, $matches ) ) {
                 $response['server_time' ] = DateTime::createFromFormat( 'Y-m-d H:i:s', "{$matches[1]} {$matches[2]}" )->format('c');
             }
-            else if( preg_match( "/^Last\sreboot\son\s([0-9\-]+)\s([0-9\:]+)\s*$/", $line, $matches ) ) {
+            else if( preg_match( "/^Last\sreboot\son\s([0-9\-]+)\s([0-9\:]+)[0-9\.]*?\s*$/", $line, $matches ) ) {
                 $response['last_reboot' ] = DateTime::createFromFormat( 'Y-m-d H:i:s', "{$matches[1]} {$matches[2]}" )->format('c');
             }
-            else if( preg_match( "/^Last\sreconfiguration\son\s([0-9\-]+)\s([0-9\:]+)\s*$/", $line, $matches ) ) {
+            else if( preg_match( "/^Last\sreconfiguration\son\s([0-9\-]+)\s([0-9\:]+)[0-9\.]*?\s*$/", $line, $matches ) ) {
                 $response['last_reconfig' ] = DateTime::createFromFormat( 'Y-m-d H:i:s', "{$matches[1]} {$matches[2]}" )->format('c');
             }
 


### PR DESCRIPTION
BIRD2.0.7 seems to have millisecond accuracy on the timestamps, this patch discards them in the regex